### PR TITLE
Enhance CI workflow for multi-platform Docker builds

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -30,6 +33,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             secrover/secrover:latest
             secrover/secrover:${{ github.ref_name }}


### PR DESCRIPTION

Excellent project!  If you need it, this PR adds `linux/arm64` platform to the Docker container builds.

Without this, the Docker command fails on Mac:

```sh
docker pull secrover/secrover && docker run --rm \
  -v "$(pwd)/config.yaml:/app/config.yaml" \
  -v "$(pwd)/output:/output" \
  -e CONFIG_FILE=config.yaml \
  secrover/secrover
Using default tag: latest

Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest
  list entries: no match for platform in manifest: not found
```

Without this PR, the work around is to add the `--platform linux/amd64` flag to the docker commands to have it run in emulated mode.  (which is an extra step but fine too)
